### PR TITLE
Laverita v3 support

### DIFF
--- a/src-slider_io/src/device/config.rs
+++ b/src-slider_io/src/device/config.rs
@@ -5,6 +5,7 @@ pub enum HardwareSpec {
   TasollerOne,
   TasollerTwo,
   Yuancon,
+  YuanconThree,
   Yubideck,
   YubideckThree,
 }
@@ -48,6 +49,10 @@ impl DeviceMode {
       },
       "yuancon" => DeviceMode::Hardware {
         spec: HardwareSpec::Yuancon,
+        disable_air: v["disableAirStrings"].as_bool()?,
+      },
+      "yuancon-three" => DeviceMode::Hardware {
+        spec: HardwareSpec::YuanconThree,
         disable_air: v["disableAirStrings"].as_bool()?,
       },
       "yubideck" => DeviceMode::Hardware {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -196,6 +196,7 @@
           <option value="tasoller-one">GAMO2 Tasoller, 1.0 HID Firmware</option>
           <option value="tasoller-two">GAMO2 Tasoller, 2.0 HID Firmware</option>
           <option value="yuancon">Yuancon Laverita, HID Firmware</option>
+          <option value="yuancon-three">Yuancon Laverita v3, HID Firmware</option>
           <option value="yubideck">大四 / Yubideck, HID Firmware 1.0</option>
           <option value="yubideck-three">大四 / Yubideck, HID Firmware 3.0</option>
           <option value="diva">Slider over Serial</option>


### PR DESCRIPTION
Tested on my own controller

Laverita v3 seems to require USB interface number 3. Couldn't find a way around it

Protocol information from https://gitea.tendokyu.moe/beerpsi/chuniio-rs/src/branch/trunk/src/backends/laverita_v3.rs

```
# Laverita v3
USB device: 0518:2022

USB interface: 3

## Protocol information

### IN Interrupt (0x83)
- Content length: 34 bytes
- Byte 0: Service, Test and Air sensors
  - From MSB to LSB:  X X X X  X X X X
  - Service:          ^
  - Test:               ^
  - Air sensors:          5 6  3 4 1 2
- Byte 1: 0x00
- Bytes 2..33: Slider pressure (top -> bottom, then left -> right)

### OUT Interrupt (0x03)
- Total Content length: 122 bytes
- Split into 2 packets
- Packet 0 (61 bytes):
  - Byte 0: Packet index (0x00)
  - Bytes 1..60: Slider LEDs 1-20 (RGB order, right -> left)
- Packet 1 (61 bytes):
  - Byte 0: Packet index (0x01)
  - Bytes 1..33: Slider LEDs 21-31 (RGB order, right -> left)
  - Bytes 34..60: Empty padding
```